### PR TITLE
_people/david: fix short_name

### DIFF
--- a/_people/david.md
+++ b/_people/david.md
@@ -1,12 +1,12 @@
 ---
-short_name: David
+short_name: david
 name: Ivo Fagundes David de Oliveira
-email: ivo.david@uni-oldenburg.de 
+email: ivo.david@uni-oldenburg.de
 link: https://rtg-cause.github.io/people/david
 role: fellow
 ---
 
-I am currently a research assistant under Prof. Verena Klös in the Self-Explaining Adaptive Software Project through through CAUSE at the University of Oldenburg. My past research interests include decision theory, multi-objective optimization and machine learning. 
+I am currently a research assistant under Prof. Verena Klös in the Self-Explaining Adaptive Software Project through through CAUSE at the University of Oldenburg. My past research interests include decision theory, multi-objective optimization and machine learning.
 
 # Past Research Topics
 - Machine Learning for Rank Estimation


### PR DESCRIPTION
Fix `short_name` in `david.md`, which prevented being listed in the projects page, and failed to load photo.