### PR TITLE
Make people page portraits a uniform size

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -22,6 +22,19 @@ h2.bibliography {
 
 @import "bootstrap";
 
+// Portraits on the people page vary in size and aspect ratio (most are
+// 500x520, a few are square, landscape or very small). Force them all into
+// the same box so the cards in a grid row line up. The ratio matches the
+// majority of the images, so only the outliers are cropped; the crop is
+// biased upwards to keep faces in frame.
+.person-portrait {
+    aspect-ratio: 25 / 26;
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+    object-position: center 25%;
+}
+
 .fc-event {
     cursor: pointer;
 }

--- a/people.html
+++ b/people.html
@@ -12,7 +12,7 @@ title: People
   {% for person in site.people %}
     {% if person.role == "fellow" %}
       <div class="g-col-12 g-col-md-6 g-col-lg-4 g-col-xxl-3">
-        <div class="card">
+        <div class="card h-100">
           {% assign portrait = site.static_files | where: "basename", person.short_name | where: "extname", ".webp" | first %}
           {% if portrait == nil %}
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
@@ -39,7 +39,7 @@ title: People
   {% for person in site.people %}
     {% if person.role == "associate" %}
       <div class="g-col-12 g-col-md-6 g-col-lg-4 g-col-xxl-3">
-        <div class="card">
+        <div class="card h-100">
           {% assign portrait = site.static_files | where: "basename", person.short_name | where: "extname", ".webp" | first %}
           {% if portrait == nil %}
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
@@ -66,7 +66,7 @@ title: People
   {% for person in site.people %}
     {% if person.role == "researcher" %}
       <div class="g-col-12 g-col-md-6 g-col-lg-4 g-col-xxl-3">
-        <div class="card">
+        <div class="card h-100">
           {% assign portrait = site.static_files | where: "basename", person.short_name | where: "extname", ".webp" | first %}
           {% if portrait == nil %}
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
@@ -93,7 +93,7 @@ title: People
   {% for author in site.people %}
     {% if author.role == "supervisor" %}
       <div class="g-col-12 g-col-md-6 g-col-lg-4 g-col-xxl-3">
-        <div class="card">
+        <div class="card h-100">
           {% assign portrait = site.static_files | where: "basename", author.short_name | where: "extname", ".webp" | first %}
           <img
             class="img-fluid person-portrait"
@@ -117,7 +117,7 @@ title: People
   {% for person in non_hidden_people %}
     {% if person.role == "advisor" %}
       <div class="g-col-12 g-col-md-6 g-col-lg-4 g-col-xxl-3">
-        <div class="card">
+        <div class="card h-100">
           {% assign portrait = site.static_files | where: "basename", person.short_name | where: "extname", ".webp" | first %}
           {% if portrait == nil %}
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
@@ -142,7 +142,7 @@ title: People
   {% for person in site.people %}
     {% if person.role == "coordinator" %}
       <div class="g-col-12 g-col-md-6 g-col-lg-4 g-col-xxl-3">
-        <div class="card">
+        <div class="card h-100">
           {% assign portrait = site.static_files | where: "basename", person.short_name | where: "extname", ".webp" | first %}
           {% if portrait == nil %}
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}

--- a/people.html
+++ b/people.html
@@ -18,7 +18,7 @@ title: People
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
           {% endif %}
           <img
-            class="img-fluid bg-secondary bg-gradient"
+            class="img-fluid person-portrait bg-secondary bg-gradient"
             src="{{ portrait.path }}"
             alt="Portrait {{ person.name }}" />
           <div class="card-body">
@@ -45,7 +45,7 @@ title: People
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
           {% endif %}
           <img
-            class="img-fluid bg-secondary bg-gradient"
+            class="img-fluid person-portrait bg-secondary bg-gradient"
             src="{{ portrait.path }}"
             alt="Portrait {{ person.name }}" />
           <div class="card-body">
@@ -72,7 +72,7 @@ title: People
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
           {% endif %}
           <img
-            class="img-fluid bg-secondary bg-gradient"
+            class="img-fluid person-portrait bg-secondary bg-gradient"
             src="{{ portrait.path }}"
             alt="Portrait {{ person.name }}" />
           <div class="card-body">
@@ -96,7 +96,7 @@ title: People
         <div class="card">
           {% assign portrait = site.static_files | where: "basename", author.short_name | where: "extname", ".webp" | first %}
           <img
-            class="img-fluid"
+            class="img-fluid person-portrait"
             src="{{ portrait.path }}"
             alt="Portrait {{ author.name }}" />
           <div class="card-body">
@@ -123,7 +123,7 @@ title: People
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
           {% endif %}
           <img
-            class="img-fluid bg-secondary bg-gradient"
+            class="img-fluid person-portrait bg-secondary bg-gradient"
             src="{{ portrait.path }}"
             alt="Portrait {{ person.name }}" />
           <div class="card-body">
@@ -148,7 +148,7 @@ title: People
             {% assign portrait = site.static_files | where: "basename", "person" | where: "extname", ".webp" | first %}
           {% endif %}
           <img
-            class="img-fluid bg-secondary bg-gradient"
+            class="img-fluid person-portrait bg-secondary bg-gradient"
             src="{{ portrait.path }}"
             alt="Portrait {{ person.name }}" />
           <div class="card-body">


### PR DESCRIPTION
Portraits on the people page came in mixed sizes and aspect ratios, so cards in
the same grid row ended up different heights and the names stopped lining up.
They are now all rendered at the same size, and the cards stay even when a long
name wraps to two lines.